### PR TITLE
Includes definition for cslreferences environment

### DIFF
--- a/digra.latex
+++ b/digra.latex
@@ -62,6 +62,19 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{11pt}}
 
+
+%Defines cslreferences environment
+%Required by pandoc 2.8
+%Copied from https://github.com/rstudio/rmarkdown/issues/1649
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
   
 %Copyright notice
 \setlength{\fboxsep}{3pt}


### PR DESCRIPTION
Pandoc 2.8 requires a cslreferences environment to be defined in a LaTeX template for CSL bibliographies. This PR includes some code copied from https://github.com/rstudio/rmarkdown/issues/1649, defining a cslreferences in the LaTeX template.

This will close issue #3.